### PR TITLE
feat: サンプルクエリ追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ anyhow = "1.0.81"
 sqlx = { version = "0.7.4", features = ["runtime-tokio-rustls", "macros", "mysql"] }
 #乱数
 rand = "0.8.5"
+# GraphQL
+async-graphql = "7.0.5"
+async-graphql-axum = "7.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ anyhow = "1.0.81"
 sqlx = { version = "0.7.4", features = ["runtime-tokio-rustls", "macros", "mysql"] }
 #乱数
 rand = "0.8.5"
-# GraphQL
+#GraphQL
 async-graphql = "7.0.5"
 async-graphql-axum = "7.0.5"
+#Utility
+futures-util = "0.3.30"
+#Stream
+async-stream = "0.3.5"
+futures-timer = "3.0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
-use async_graphql::{
-    http::GraphiQLSource, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject,
-};
-use async_graphql_axum::GraphQL;
+use async_graphql::{http::GraphiQLSource, Object, Schema, SimpleObject, Subscription};
+use async_graphql_axum::{GraphQL, GraphQLSubscription};
 use axum::{
     response::{self, IntoResponse},
     routing::get,
     Router,
 };
+use futures_util::stream::Stream;
+use std::time::Duration;
 use tokio::net::TcpListener;
 
 #[derive(SimpleObject, sqlx::FromRow)]
@@ -15,6 +15,7 @@ struct Ping {
     code: i32,
 }
 
+// Query
 struct QueryRoot;
 
 #[Object]
@@ -27,15 +28,52 @@ impl QueryRoot {
     }
 }
 
+// Mutation
+struct MutationRoot;
+
+#[Object]
+impl MutationRoot {
+    async fn add(&self, a: i32, b: i32) -> i32 {
+        a + b
+    }
+}
+
+// Subscription
+struct SubscriptionRoot;
+
+#[Subscription]
+impl SubscriptionRoot {
+    async fn interval(&self, #[graphql(default = 1)] n: i32) -> impl Stream<Item = i32> {
+        let mut value = 0;
+        async_stream::stream! {
+            loop {
+                futures_timer::Delay::new(Duration::from_secs(1)).await;
+                value += n;
+                yield value;
+            }
+        }
+    }
+}
+
 async fn graphiql() -> impl IntoResponse {
-    response::Html(GraphiQLSource::build().endpoint("/").finish())
+    response::Html(
+        GraphiQLSource::build()
+            .endpoint("/")
+            .subscription_endpoint("/ws")
+            .finish(),
+    )
 }
 
 #[tokio::main]
 async fn main() {
-    let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish();
+    let schema = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot).finish();
 
-    let app = Router::new().route("/", get(graphiql).post_service(GraphQL::new(schema)));
+    let app = Router::new()
+        .route(
+            "/",
+            get(graphiql).post_service(GraphQL::new(schema.clone())),
+        )
+        .route_service("/ws", GraphQLSubscription::new(schema));
 
     println!("GraphiQL IDE: http://localhost:8000");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,45 @@
-fn main() {
-    println!("Hello, world!");
+use async_graphql::{
+    http::GraphiQLSource, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject,
+};
+use async_graphql_axum::GraphQL;
+use axum::{
+    response::{self, IntoResponse},
+    routing::get,
+    Router,
+};
+use tokio::net::TcpListener;
+
+#[derive(SimpleObject, sqlx::FromRow)]
+struct Ping {
+    status: String,
+    code: i32,
+}
+
+struct QueryRoot;
+
+#[Object]
+impl QueryRoot {
+    async fn ping(&self) -> Ping {
+        Ping {
+            status: "ok".to_string(),
+            code: 200,
+        }
+    }
+}
+
+async fn graphiql() -> impl IntoResponse {
+    response::Html(GraphiQLSource::build().endpoint("/").finish())
+}
+
+#[tokio::main]
+async fn main() {
+    let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish();
+
+    let app = Router::new().route("/", get(graphiql).post_service(GraphQL::new(schema)));
+
+    println!("GraphiQL IDE: http://localhost:8000");
+
+    axum::serve(TcpListener::bind("0.0.0.0:8000").await.unwrap(), app)
+        .await
+        .unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,14 @@ use async_graphql::{http::GraphiQLSource, Object, Schema, SimpleObject, Subscrip
 use async_graphql_axum::{GraphQL, GraphQLSubscription};
 use axum::{
     response::{self, IntoResponse},
-    routing::{get, post_service},
+    routing::get,
     Router,
 };
 use futures_util::stream::Stream;
 use std::time::Duration;
 use tokio::net::TcpListener;
 
-#[derive(SimpleObject, sqlx::FromRow)]
+#[derive(SimpleObject)]
 struct Ping {
     status: String,
     code: i32,
@@ -58,7 +58,7 @@ impl SubscriptionRoot {
 async fn graphiql() -> impl IntoResponse {
     response::Html(
         GraphiQLSource::build()
-            .endpoint("/")
+            .endpoint("/graphql")
             .subscription_endpoint("/ws")
             .finish(),
     )
@@ -69,8 +69,10 @@ async fn main() {
     let schema = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot).finish();
 
     let app = Router::new()
-        .route("/", post_service(GraphQL::new(schema.clone())))
-        .route("/graphiql", get(graphiql))
+        .route(
+            "/graphql",
+            get(graphiql).post_service(GraphQL::new(schema.clone())),
+        )
         .route_service("/ws", GraphQLSubscription::new(schema));
 
     println!("GraphiQL IDE: http://localhost:8000/graphiql");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use async_graphql::{http::GraphiQLSource, Object, Schema, SimpleObject, Subscrip
 use async_graphql_axum::{GraphQL, GraphQLSubscription};
 use axum::{
     response::{self, IntoResponse},
-    routing::get,
+    routing::{get, post_service},
     Router,
 };
 use futures_util::stream::Stream;
@@ -69,13 +69,11 @@ async fn main() {
     let schema = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot).finish();
 
     let app = Router::new()
-        .route(
-            "/",
-            get(graphiql).post_service(GraphQL::new(schema.clone())),
-        )
+        .route("/", post_service(GraphQL::new(schema.clone())))
+        .route("/graphiql", get(graphiql))
         .route_service("/ws", GraphQLSubscription::new(schema));
 
-    println!("GraphiQL IDE: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000/graphiql");
 
     let server = TcpListener::bind("0.0.0.0:8000").await;
     if let Err(e) = server {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,10 @@ async fn main() {
 
     println!("GraphiQL IDE: http://localhost:8000");
 
-    axum::serve(TcpListener::bind("0.0.0.0:8000").await.unwrap(), app)
-        .await
-        .unwrap();
+    let server = TcpListener::bind("0.0.0.0:8000").await;
+    if let Err(e) = server {
+        eprintln!("Error: {}", e);
+        return;
+    }
+    axum::serve(server.unwrap(), app).await.unwrap();
 }


### PR DESCRIPTION
GraphQLクエリのサンプルを追加しました。

## 検証

GraphiQL (http://localhost:8000/graphql) で確認できます。

### Query

リクエスト
```
query sampleQuery {
  ping {
    status
    code
  }
}
```

レスポンス
```
{
  "data": {
    "ping": {
      "status": "ok",
      "code": 200
    }
  }
}
```

### Mutation

リクエスト
```
mutation sampleMutation {
  add(a: 1, b: 1)
}
```

レスポンス
```
{
  "data": {
    "add": 2
  }
}
```

### Subscription

リクエスト
```
subscription sampleSubscription {
  interval
}
```

レスポンス
```
{
  "data": {
    "interval": 2
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - GraphQLサポートを追加し、ping、add、intervalクエリを含むGraphQLサーバーを設定。
  - GraphiQL IDEエンドポイントを追加。

- **依存関係の更新**
  - `async-graphql`、`async-graphql-axum`、`futures-util`、`async-stream`、`futures-timer`の依存関係を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->