### PR TITLE
RustアプリケーションをDockerでもローカルでも動作できるように

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=mysql://user:password@db:3306/music_sync
+DATABASE_URL="mysql://user:password@localhost:3306/music_sync"

--- a/README.md
+++ b/README.md
@@ -2,17 +2,51 @@
 
 ## Setup
 
-コンテナ立ち上げ．
+Rustアプリケーションは `Docker` と `ローカル` のどちらで動かしても大丈夫です。
+
+### RustアプリケーションをDockerで動かしたい場合
+
+コンテナ立ち上げ。
 
 ```
 docker compose up -d
 ```
 
-マイグレーション
+マイグレーション。
 
 ```
+docker compose exec app bash
 make migrate
 ```
+
+### RustアプリケーションをLocalで動かしたい場合
+
+コンテナ立ち上げ（DBのみ）。
+
+```
+docker compose up db -d
+```
+
+マイグレーション。
+
+```
+cargo install sqlx-cli
+make migrate
+```
+
+Rustアプリケーション実行。
+
+```
+cargo run
+```
+
+コードの変更を監視し、自動で `cargo run` したい場合。
+
+```
+cargo install cargo-watch
+cargo watch -x run
+```
+
 
 ### Docker containers
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,8 @@ services:
       - "8000:8000"
     volumes:
       - .:/usr/src/myapp
+    environment:
+      DATABASE_URL: "mysql://user:password@db:3306/music_sync"
     depends_on:
       - db
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.77.1"
+components = ["rustc", "cargo"]
+profile = "minimal"
+targets = []


### PR DESCRIPTION
# 概要

`rust-toolchain.toml`でのRustのバージョン指定により、ローカルでRustアプリケーションを実行してもバージョン違いが起きないようにしました。

また、Docker側とローカル側で`DATABASE_URL`が異なるため、それぞれで違う環境変数が使用されるように修正しました。
以下２つのファイルで`DATABASE_URL`が指定されています。
- `.env`: ローカル環境で使用される
- `compose.yaml`: Docker環境のRustアプリで参照される

## 関連ISSUE

- #62 

## Close

Close #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - READMEにDockerおよびローカル環境でのRustアプリケーションのセットアップ手順を追加しました。

- **設定変更**
  - `.env`ファイルの`DATABASE_URL`を`db`から`localhost`に変更しました。
  - `compose.yaml`で`DATABASE_URL`の環境変数設定を追加し、MySQLデータベースへの接続を設定しました。

- **ツールチェイン**
  - `rust-toolchain.toml`にRustツールチェインの設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->