### PR TITLE
Room作成のMutationの実装

### DIFF
--- a/src/domain_service/room_repository_trait.rs
+++ b/src/domain_service/room_repository_trait.rs
@@ -7,5 +7,6 @@ pub trait RoomRepositoryTrait: Send + Sync {
     async fn find_by_room_pin(&self, room_pin: String) -> Result<Room>;
     async fn save(&self, room: Room) -> Result<Room>;
     async fn delete(&self, room: Room, user: GuestUser) -> Result<()>;
+    async fn is_active(&self, room_pin: String) -> Result<bool>;
     async fn check_existence(&self, room_pin: String) -> Result<bool>;
 }

--- a/src/infrastructure/room_repository.rs
+++ b/src/infrastructure/room_repository.rs
@@ -107,7 +107,7 @@ impl RoomRepositoryTrait for RoomRepository {
         Ok(())
     }
 
-    async fn check_existence(&self, room_pin: String) -> Result<bool> {
+    async fn is_active(&self, room_pin: String) -> Result<bool> {
         let room_data = sqlx::query_as!(
             RoomData,
             r#" 
@@ -126,6 +126,21 @@ impl RoomRepositoryTrait for RoomRepository {
             Ok(true)
         } else {
             Ok(false)
+        }
+    }
+
+    async fn check_existence(&self, room_pin: String) -> Result<bool> {
+        let result = sqlx::query!(
+            r#"SELECT COUNT(*) as count FROM rooms WHERE room_pin = ?"#,
+            room_pin
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        if result.count == 0 {
+            Ok(false)
+        } else {
+            Ok(true)
         }
     }
 }

--- a/src/infrastructure/user_repository.rs
+++ b/src/infrastructure/user_repository.rs
@@ -19,7 +19,15 @@ impl UserRepository {
 #[async_trait]
 impl UserRepositoryTrait for UserRepository {
     async fn find_by_id(&self, id: UserID) -> Result<GuestUser> {
-        todo!()
+        let user = sqlx::query_as!(
+            GuestUser,
+            r#"SELECT id, username, user_type FROM users WHERE id = ?"#,
+            id.raw_value()
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(user)
     }
 
     async fn find_all(&self) -> Result<Vec<GuestUser>> {

--- a/src/resolver/mutation_root_resolver.rs
+++ b/src/resolver/mutation_root_resolver.rs
@@ -1,6 +1,9 @@
 use async_graphql::{Context, Error, Object, Result};
 
 use crate::domain_model::music_library::music_library::{MusicLibrary, MusicLibraryInput};
+use crate::domain_model::room::room::Room;
+use crate::domain_model::room::value_object::room_pin::RoomPin;
+use crate::domain_model::user::value_object::user_id::{UserID, UserIDInput};
 use crate::Dependency;
 
 // Mutation
@@ -20,5 +23,49 @@ impl MutationRoot {
         }
         let music_library = result.unwrap();
         Ok(music_library)
+    }
+
+    pub async fn create_room<'ctx>(
+        &self,
+        ctx: &Context<'ctx>,
+        user_id: UserIDInput,
+    ) -> Result<Room> {
+        let ctx = ctx.data::<Dependency>().unwrap();
+
+        // get host user
+        let result = ctx
+            .get_user_repository()
+            .find_by_id(UserID::new(user_id.value))
+            .await;
+        if result.is_err() {
+            return Err(Error::from(result.err().unwrap()));
+        }
+        let host = result.unwrap();
+
+        // issue new room pin
+        let mut room_pin;
+        loop {
+            room_pin = RoomPin::random_new();
+            let result = ctx
+                .get_room_repository()
+                .check_existence(room_pin.raw_value())
+                .await;
+            if result.is_err() {
+                return Err(Error::from(result.err().unwrap()));
+            }
+            let exists = result.unwrap();
+            if !exists {
+                break;
+            }
+        }
+
+        // create new room
+        let room = Room::new(room_pin, host.id, true, vec![]);
+        let result = ctx.get_room_repository().save(room).await;
+        if result.is_err() {
+            return Err(Error::from(result.err().unwrap()));
+        }
+        let room = result.unwrap();
+        Ok(room)
     }
 }


### PR DESCRIPTION
## 概要・変更点

ホストが最初にルームを作成するのに必要なMutationを実装しました。


## 関連ISSUE
- #55 


## CloseするISSUE
<!--
以下のように指定すると、このPRがマージされると勝手にこれらISSUEがCloseされる。

Close #40
Close #41
-->

Close #55 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しいルーム作成機能を追加。ユニークなピンを持つルームを作成し、ホストユーザーを割り当てて保存します。
  - ルームの存在を確認する機能を追加。指定されたピンでルームがアクティブかどうかを確認できます。

- **機能改善**
  - `find_by_id` 関数を更新。指定されたIDに基づいてデータベースからゲストユーザーをフェッチして返します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->